### PR TITLE
Fix issue #12 - format JIDO_API_PORT env var as a number

### DIFF
--- a/api/v1/core/api.l
+++ b/api/v1/core/api.l
@@ -8,7 +8,7 @@
 
 (setq
   *PR_SET_NAME    15
-  *JIDO_API_PORT  (if (sys "JIDO_API_PORT") @ 8080) )
+  *JIDO_API_PORT  (if (format (sys "JIDO_API_PORT")) @ 8080) )
 
 [de https-start ()
   (when (sys "JIDO_WITH_SSL")


### PR DESCRIPTION
The format function converts between number and string types. A numeric string will thus be converted to an integer type, while an alphanumeric string will return NIL.
